### PR TITLE
CMake: allow to build shared arsenalgear + restore option to disable tests + use compile feature for C++17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,9 +15,6 @@ if( EXISTS "${LOC_PATH}" )
                          "remove CMakeCache.txt and CMakeFiles." )
 endif()
 
-# Fetching dependencies
-add_subdirectory( deps )
-
 # Include directories
 include_directories( ${CMAKE_CURRENT_SOURCE_DIR}/include )
 
@@ -51,7 +48,11 @@ if( CMAKE_BUILD_TYPE STREQUAL "Debug" )
 endif()
 
 # Compile tests
-if( CMAKE_BUILD_TYPE STREQUAL "Debug" )
+option( ARSENALGEAR_TESTS "Enable / disable tests." ON )
+if( ARSENALGEAR_TESTS )
+    # Fetching dependencies
+    add_subdirectory( deps )
+    
     add_subdirectory( test )
 else()
     message( STATUS "Skipping tests." )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,11 +15,13 @@ if( EXISTS "${LOC_PATH}" )
                          "remove CMakeCache.txt and CMakeFiles." )
 endif()
 
+include(GNUInstallDirs)
+
 # Include directories
 include_directories( ${CMAKE_CURRENT_SOURCE_DIR}/include )
 
 # Create static library
-add_library( arsenalgear STATIC
+add_library( arsenalgear
     src/stream.cpp
     src/system.cpp
     src/utils.cpp
@@ -28,6 +30,9 @@ add_library( arsenalgear::arsenalgear ALIAS arsenalgear )
 
 # Set c++ standard options
 target_compile_features(arsenalgear PUBLIC cxx_std_17)
+
+# Export symbols for Visual Studio in case of shared lib
+set_target_properties(arsenalgear PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
 
 # Adding specific compiler flags
 if( CMAKE_CXX_COMPILER_ID STREQUAL "MSVC" )
@@ -66,21 +71,23 @@ target_include_directories( arsenalgear INTERFACE
 
 install(
     DIRECTORY include/arsenalgear
-    DESTINATION include
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
 
 # Creating the package files
 install( 
     TARGETS arsenalgear
     EXPORT arsenalgearTargets
-    DESTINATION lib
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
 
 install(
     EXPORT arsenalgearTargets
     FILE arsenalgearTargets.cmake
     NAMESPACE arsenalgear::
-    DESTINATION lib/cmake/arsenalgear
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/arsenalgear
 )
 
 # Configure package files
@@ -89,7 +96,7 @@ include( CMakePackageConfigHelpers )
 configure_package_config_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Config.cmake.in
     "${CMAKE_CURRENT_BINARY_DIR}/arsenalgearConfig.cmake"
-    INSTALL_DESTINATION "lib/cmake/arsenalgear"
+    INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/arsenalgear"
     NO_SET_AND_CHECK_MACRO
     NO_CHECK_REQUIRED_COMPONENTS_MACRO
 )
@@ -103,7 +110,7 @@ write_basic_package_version_file(
 install( FILES
     ${CMAKE_CURRENT_BINARY_DIR}/arsenalgearConfig.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/arsenalgearConfigVersion.cmake
-    DESTINATION lib/cmake/arsenalgear
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/arsenalgear
 )
 
 export( EXPORT arsenalgearTargets

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,11 +15,6 @@ if( EXISTS "${LOC_PATH}" )
                          "remove CMakeCache.txt and CMakeFiles." )
 endif()
 
-# Set c++ standard options
-set( CMAKE_CXX_STANDARD 17 )
-set( CMAKE_CXX_STANDARD_REQUIRED ON )
-set( CMAKE_CXX_EXTENSIONS OFF )
-
 # Fetching dependencies
 add_subdirectory( deps )
 
@@ -33,6 +28,9 @@ add_library( arsenalgear STATIC
     src/utils.cpp
 )
 add_library( arsenalgear::arsenalgear ALIAS arsenalgear )
+
+# Set c++ standard options
+target_compile_features(arsenalgear PUBLIC cxx_std_17)
 
 # Adding specific compiler flags
 if( CMAKE_CXX_COMPILER_ID STREQUAL "MSVC" )

--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -16,6 +16,4 @@ if( EXISTS "${LOC_PATH}" )
 endif()
 
 # Fetch optional deps
-if( CMAKE_BUILD_TYPE STREQUAL "Debug" )
-    add_subdirectory( doctest )
-endif()
+add_subdirectory( doctest )


### PR DESCRIPTION
- enable C++17 or higher with compile feature instead of CMAKE_CXX_STANDARD as it is recommended for libraries (and remove CMAKE_CXX_EXTENSIONS as it is not a usage requirement of arsenalgear, but a choice which should be left to users): 
  - compile feature can be overridden by users with CMAKE_CXX_STANDARD (as soon as it is the same standard or more recent), while a hardcoded CMAKE_CXX_STANDARD cannot
  - compile features are propagated in CMake imported targets of CMake config file, CMAKE_CXX_STANDARD is not propgated
- restore `ARSENALGEAR_TESTS`. Removing this option is problematic for package managers. They don't want to build tests, and they don't want to download and build doctest at build time. Moreover it pollutes install folder of arsenalgear with doctest headers.
- allow to build shared arsenalgear